### PR TITLE
Set 'Find us on GitHub' button href to GitHub organization page

### DIFF
--- a/src/components/modules/Home/Organization/Organization.js
+++ b/src/components/modules/Home/Organization/Organization.js
@@ -54,7 +54,10 @@ export default function Organization() {
             contributors to grow our platform and continue serving our students!
           </div>
           <div className={style.CtaSection_ButtonArea}>
-            <Button className={style.CtaSection_Button}>
+            <Button
+              className={style.CtaSection_Button}
+              href="https://github.com/dev-launchers"
+            >
               Find us on GitHub
             </Button>
           </div>


### PR DESCRIPTION
Also set logo, url, description, etc. on GitHub Organization page (https://github.com/dev-launchers) to make it look sort of nice. Closes #37 