### PR TITLE
Fixed broken links on Learn page.

### DIFF
--- a/src/components/common/EntryCard/EntryCard.js
+++ b/src/components/common/EntryCard/EntryCard.js
@@ -5,17 +5,13 @@ export default function EntryCard(props) {
   return (
     <div className={style.entry} key={props.i}>
       <div className={style.entryHeading}>
-        <a
-          className={style.entryTitle}
-          href={props.entry.sandboxUrl}
-          target="_blank"
-        >
+        <a className={style.entryTitle} href={props.entry.href} target="_blank">
           {props.entry.title}
         </a>
       </div>
       <div className={style.entryContent}>
         <div className={style.entryImageHolder}>
-          <a href={props.entry.sandboxUrl} target="_blank">
+          <a href={props.entry.href} target="_blank">
             <img src={props.entry.imageSrc} className={style.entryImage} />
           </a>
         </div>


### PR DESCRIPTION
Updated the EntryCard component to get link data from 'href' prop.  NOTE: Since Create shares the same EntryCard component, links will be broken on the Create page until app_db-curriculum is updated. 