### PR TITLE
Integrated Context API tied to Google Sheets data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3395,8 +3395,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3414,13 +3413,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3433,18 +3430,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3547,8 +3541,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3558,7 +3551,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3571,20 +3563,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3601,7 +3590,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3682,8 +3670,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3693,7 +3680,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3769,8 +3755,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3800,7 +3785,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3818,7 +3802,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3857,13 +3840,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -4291,6 +4272,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+    },
+    "constate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constate/-/constate-2.0.0.tgz",
+      "integrity": "sha512-oYpbnxDH1BSZTyBHGpSabuT0h/rLU7UDTC8p8J/TLt8G69ePIHCaNyDCz+LUl1QJpCrzrk0jO4D524rJlh4edg=="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -8706,15 +8692,13 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
@@ -8815,8 +8799,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     }
   },
   "dependencies": {
+    "constate": "^2.0.0",
     "firebase": "^7.6.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",

--- a/src/components/modules/App/App.js
+++ b/src/components/modules/App/App.js
@@ -10,6 +10,8 @@ import * as firebase from "firebase/app";
 import "firebase/auth";
 import firebaseConfig from "../../../utils/firebaseConfig.js";
 
+import { useSheetsContext } from "../../../context/SheetsContext";
+
 import ScrollToTop from "../../../utils/ScrollToTop.js";
 import HomeRoute from "../../../routes/HomeRoute.js";
 import CreateRoute from "../../../routes/CreateRoute.js";
@@ -25,25 +27,27 @@ function App(props) {
   const { user, signOut, signInWithGithub } = props;
 
   return (
-    <div className="App">
-      <ToastContainer
-        className="toast-container"
-        toastClassName="toast"
-        progressClassName="toast-progress"
-      />
-      <Router basename={process.env.PUBLIC_URL}>
-        <ScrollToTop />
-        <Switch>
-          <Route exact path="/" component={HomeRoute} />
-          <Route exact path="/create" component={CreateRoute} />
-          <Route exact path="/learn" component={LearnRoute} />
-          <Route exact path="/play" component={PlayRoute} />
-          <Route exact path="/earn" component={EarnRoute} />
-          <Route exact path="/events" component={EventsRoute} />
-          <Route exact path="/support-us" component={SupportUsRoute} />
-        </Switch>
-      </Router>
-    </div>
+    <useSheetsContext.Provider>
+      <div className="App">
+        <ToastContainer
+          className="toast-container"
+          toastClassName="toast"
+          progressClassName="toast-progress"
+        />
+        <Router basename={process.env.PUBLIC_URL}>
+          <ScrollToTop />
+          <Switch>
+            <Route exact path="/" component={HomeRoute} />
+            <Route exact path="/create" component={CreateRoute} />
+            <Route exact path="/learn" component={LearnRoute} />
+            <Route exact path="/play" component={PlayRoute} />
+            <Route exact path="/earn" component={EarnRoute} />
+            <Route exact path="/events" component={EventsRoute} />
+            <Route exact path="/support-us" component={SupportUsRoute} />
+          </Switch>
+        </Router>
+      </div>
+    </useSheetsContext.Provider>
   );
 }
 

--- a/src/context/SheetsContext.js
+++ b/src/context/SheetsContext.js
@@ -1,0 +1,76 @@
+import React from "react";
+import createUseContext from "constate"; // State Context Object Creator
+
+import Tabletop from "tabletop";
+
+// Built from this article: https://www.sitepoint.com/replace-redux-react-hooks-context-api/
+
+// Step 1: Create a custom hook that contains your state and actions
+function useSheets() {
+  const [learnPageData, setLearnPageData] = React.useState({});
+  const [createPageData, setCreatePageData] = React.useState({});
+
+  // Fetch sheets data using Tabletop when hook is initialized
+  React.useEffect(() => {
+    Tabletop.init({
+      key: "1QV419fM2DHZM59mFK6eYYbYiq6bs4sBUpTwVZ_dZJNg",
+      callback: googleData => {
+        setLearnPageData(sheetsDataToPageJSON(googleData.learnPage.elements));
+        setCreatePageData(sheetsDataToPageJSON(googleData.createPage.elements));
+      },
+      simpleSheet: false
+    });
+  }, []);
+
+  // Convert data from our google sheets format to our expected JSON format
+  // When data is returned, store it in this context's state
+  const sheetsDataToPageJSON = sheetsElements => {
+    /*
+     *  Converts data from a row based spreadsheet into a nested JSON object representing our page structure
+     *  JSON Format:
+     *    {
+     *      tabName: {
+     *        sectionName: {
+     *          groupName: [
+     *            entryObject1,
+     *            entryObject2,
+     *            ...
+     *          ]
+     *        },
+     *        ...
+     *      },
+     *      ...
+     *    }
+     */
+    let pageData = {};
+    sheetsElements.forEach((element, i) => {
+      if (element.isActive == "TRUE") {
+        const tab = element.tab;
+        const section = element.section;
+        const group = element.group;
+        const activity = {
+          title: element.title,
+          description: element.description,
+          href: element.url,
+          imageSrc: element.imageSrc
+        };
+
+        // if tab doesn't exist yet, create it
+        if (!(tab in pageData)) pageData[tab] = {};
+        // if section in this tab doesn't exist yet, create it
+        if (!(section in pageData[tab])) pageData[tab][section] = {};
+        // if group in this section doesn't exist yet, create it
+        if (!(group in pageData[tab][section]))
+          pageData[tab][section][group] = [];
+
+        pageData[tab][section][group].push(activity);
+      }
+    });
+    return pageData;
+  };
+
+  return { learnPageData, createPageData };
+}
+
+// Step 2: Declare your context state object to share the state with other components
+export const useSheetsContext = createUseContext(useSheets);


### PR DESCRIPTION
Closes #5 

Context api has been integrated, but is not yet used. We can now implement the 'useSheetsContext' hook to access shared data containing the content for our 'Learn' and 'Create' pages, which is stored in one central location. This context is currently provided to the entire app, and loads it's data from the Google Sheets API once when the app is loaded.

Next steps are to use this shared context in both the 'Create' page (#49) and the 'Learn' page (#50)