### PR TITLE
Use semantic versioning to tag releases

### DIFF
--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -1,22 +1,25 @@
 name: release-publish
 on:
-  # Only trigger if the pull request is closed.
-  pull_request:
-    types: [ closed ]
+  release:
+    types: [published]
 jobs:
   build:
-    # A pull request can be closed without merging. This check makes sure it's merged
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # GITHUB_REF is tag of the release https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
+          ref: ${{ github.ref }}
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: devlaunchers/platform-website # list of Docker images to use as base name for tags
-          tag-sha: true # add git short SHA as Docker tag
+          tag-semver: |
+            {{version}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: release
+on:
+  push:
+    branches:
+      - release
+    paths-ignore:
+      - 'staging/flux-patch.yaml'
+      - 'production/flux-patch.yaml'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Release
+        env:
+          # Events triggered by the GITHUB_TOKEN will not create a new workflow, as a workaround we can call the env GH_TOKEN
+          # https://github.com/semantic-release/github accepts GH_TOKEN and GITHUB_TOKEN
+          # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: npx semantic-release

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ We’re currently partnered with the Austin Public Library and run weekly labs f
 3. Run dev version: `npm run start`
 
 ---
+
+## Release
+
+We are using semantic versioning to tag release. Follow https://github.com/semantic-release/semantic-release#commit-message-format
+to format the commit messages.
+
+Once you are ready to create a new release, create a PR to merge main branch to release branch.
+
+---
  
 ## License
 

--- a/production/flux-patch.yaml
+++ b/production/flux-patch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: platform-website
   namespace: platform-website
   annotations:
-    fluxcd.io/tag.platform-website: regex:^release-sha-*
+    fluxcd.io/tag.platform-website: semver:*
 spec:
   template:
     spec:

--- a/production/kustomization.yaml
+++ b/production/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: platform-website
 bases:
   - ../workload

--- a/staging/kustomization.yaml
+++ b/staging/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: platform-website
 bases:
   - ../workload


### PR DESCRIPTION
To create new release, merge master branch to release branch. It will trigger the github action defined in `.github/workflows/release.yaml` to cut a release. When there is a new release, `.github/workflows/docker-build-release.yaml` is triggered to build an image tagged with the version because of this step
```
- name: Docker meta
        id: docker_meta
        uses: crazy-max/ghaction-docker-meta@v1
        with:
          images: devlaunchers/platform-website # list of Docker images to use as base name for tags
          tag-semver: |
            {{version}}
```
This solves the staging vs. production separation because `production/flux-patch.yaml` adds a rule to only deploy new image that has a semantic versioned tag. 