### PR TITLE
Tag staging image with timestamp that it's built

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,6 +6,7 @@ on:
     # Build image whenever a file under src/ is changed
     paths:
       - 'src/**'
+      - '.github/workflows/docker-build.yaml'
       - 'package*.json'
 jobs:
   build:
@@ -13,12 +14,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M')"
       - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        id: meta
+        uses: docker/metadata-action@v3
         with:
           images: devlaunchers/platform-website # list of Docker images to use as base name for tags
-          tag-sha: true # add git short SHA as Docker tag
+          # generate Docker tags based on the following events/attributes
+          # flux image update policy sorts by timestamp
+          tags: |
+            type=raw,value={{sha}}-${{ steps.date.outputs.date }}
+            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -34,6 +42,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
This appends built timestamp to the docker image, similar to https://hub.docker.com/layers/149893168/devlaunchers/platform-api/9b0067e-202105161812/images/sha256-96bfd29c173afef4b4639800eb966df78a040bf6986601712179a7e904d3e624?context=explore. This is useful to compare which image is newer, and the new staging server uses https://fluxcd.io/docs/components/image/imagepolicies/#policy to determine which image is newest. 