### PR TITLE
Implement typewriter effect in home hero section

### DIFF
--- a/src/components/modules/Home/HeroOverlay/HeroOverlay.js
+++ b/src/components/modules/Home/HeroOverlay/HeroOverlay.js
@@ -15,13 +15,25 @@ import manGlassesImage from "../../../../images/people-cutouts/man-glasses.png";
 
 function TypewriterEffect(props) {
   const [initialText, setInitialText] = React.useState(props.children);
-  const [text, setText] = React.useState(initialText);
+  const [text, setText] = React.useState("");
 
-  setTimeout(() => {
-    setText(Math.random());
-  }, 1000);
+  React.useEffect(() => {
+    let characterIndex = -1;
+    // Delay typing by 1 second
+    setTimeout(() => {
+      // Begin typing
+      let interval = setInterval(() => {
+        if (characterIndex < initialText.length) {
+          characterIndex++;
+          setText(initialText.substring(0, characterIndex));
+        } else {
+          clearInterval(interval);
+        }
+      }, 50);
+    }, 1000);
+  }, []);
 
-  return <>{text}</>;
+  return <>>{text}█</>;
 }
 
 export default function HeroOverlay() {
@@ -31,8 +43,8 @@ export default function HeroOverlay() {
         <MessageArea>
           <Tagline>
             <TypewriterEffect>
-              >We build world changing software while preparing people to thrive
-              in technical careers█
+              We build world changing software while preparing people to thrive
+              in technical careers
             </TypewriterEffect>
           </Tagline>
         </MessageArea>

--- a/src/components/modules/Home/HeroOverlay/HeroOverlay.js
+++ b/src/components/modules/Home/HeroOverlay/HeroOverlay.js
@@ -13,14 +13,27 @@ import {
 
 import manGlassesImage from "../../../../images/people-cutouts/man-glasses.png";
 
+function TypewriterEffect(props) {
+  const [initialText, setInitialText] = React.useState(props.children);
+  const [text, setText] = React.useState(initialText);
+
+  setTimeout(() => {
+    setText(Math.random());
+  }, 1000);
+
+  return <>{text}</>;
+}
+
 export default function HeroOverlay() {
   return (
     <FlexPageSection>
       <Wrapper>
         <MessageArea>
           <Tagline>
-            >We build world changing software while preparing people to thrive
-            in technical careers█
+            <TypewriterEffect>
+              >We build world changing software while preparing people to thrive
+              in technical careers█
+            </TypewriterEffect>
           </Tagline>
         </MessageArea>
         <ImageArea>


### PR DESCRIPTION
I've implemented a typewriter effect for our hero section of the home page :smile: It was designed so we can eventually bump it out to a common component and use it in multiple places in the site, and then simply wrap text like so: 

<TypewriterEffect>Some text here</TypewriterEffect>


Right now, though, it is tied directly to our HeroOverlay component. 


https://user-images.githubusercontent.com/46331884/119404327-43ea8200-bca5-11eb-9f37-cd2a8e710a7b.mp4

